### PR TITLE
Datasets

### DIFF
--- a/Datasets/data
+++ b/Datasets/data
@@ -1,0 +1,1 @@
+BNNR can conduct drug-disease predictions on three datasets: Fdataset, Cdataset and DNdataset, which can be loaded by matlab.


### PR DESCRIPTION
BNNR can conduct drug-disease predictions on three datasets: Fdataset, Cdataset and DNdataset, which can be loaded by matlab.